### PR TITLE
Allow comparing a Machine to a String 

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -28,4 +28,8 @@ class MicroMachine
   rescue NoMethodError
     raise InvalidEvent
   end
+
+  def ==(some_state)
+    state == some_state
+  end
 end


### PR DESCRIPTION
This lets us redefine model methods as FSMs, and still be able to compare:

``` ruby
    class SomeModel < ActiveRecord::Base
      def activate!
        state.trigger(:activate)
        save!
      end

      def state
        @_state ||= MicroMachine.new(self[:state]).tap do |fsm|
          fsm.transitions_for[:activate] = { "pending" => "active" }
          fsm.on(:any) { self[:state] = state.state }
        end
      end
    end

    model = SomeModel.new
    model.activate!
    model.state == "active"
```
