### PR TITLE
Add contest as gem development dependency (used in tests)

### DIFF
--- a/micromachine.gemspec
+++ b/micromachine.gemspec
@@ -7,4 +7,5 @@ Gem::Specification.new do |s|
   s.email = "michel@soveran.com"
   s.homepage = "http://github.com/soveran/micromachine"
   s.files = Dir["lib/**/*.rb", "README*", "LICENSE", "Rakefile", "*.gemspec", "example/**/*.*"]
+  s.add_development_dependency 'contest'
 end


### PR DESCRIPTION
Hi!

I noticed that the "contest" gem was missing when running the tests for micromachine. I took the liberty of adding it to the gemspec as a development dependency. Hope you don’t mind, I know they’re considered holy.
