### PR TITLE
Use Hash#fetch to raise InvalidEvent on missing event

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -30,9 +30,10 @@ class MicroMachine
   end
 
   def trigger?(event)
-    transitions_for[event][state] ? true : false
-  rescue NoMethodError
-    raise InvalidEvent
+    transitions = transitions_for.fetch(event) do
+      raise InvalidEvent
+    end
+    transitions.has_key?(state)
   end
 
   def events


### PR DESCRIPTION
Hello again!

I noticed `#trigger?` rescues NoMethodError and then raises an InvalidEvent error if an event has not been defined. I changed it to use Hash#fetch with a block instead. The block is invoked when the key is missing, and from there we raise.

The semantics are the same, but we avoid raising an unnecessary error (and output of `ruby -d` when using micromachine will be a little nicer as well).
