### PR TITLE
don't rescue NoMethodError

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -30,9 +30,8 @@ class MicroMachine
   end
 
   def trigger?(event)
+    raise InvalidEvent unless transitions_for.has_key?(event)
     transitions_for[event][state] ? true : false
-  rescue NoMethodError
-    raise InvalidEvent
   end
 
   def events


### PR DESCRIPTION
I would consider rescuing `NoMethodError` as bad practice since you can easily hide programming errors. I think an explicit check if the event has been defined also communicates the intent better.
