### PR TITLE
added ability to pass arguments to trigger

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -18,11 +18,11 @@ class MicroMachine
     transitions_for[event] = transitions
   end
 
-  def trigger event
+  def trigger event, *args
     if trigger?(event)
       @state = transitions_for[event][@state]
       callbacks = @callbacks[@state] + @callbacks[:any]
-      callbacks.each { |callback| callback.call }
+      callbacks.each { |callback| callback.call(*args) }
       true
     else
       false

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -78,7 +78,7 @@ class MicroMachineTest < Test::Unit::TestCase
 
       @machine.on(:pending)   { @state = "Pending" }
       @machine.on(:confirmed) { @state = "Confirmed" }
-      @machine.on(:ignored)   { @state = "Ignored" }
+      @machine.on(:ignored)   { |a,b| @state = "#{a}: #{b}" }
       @machine.on(:any)       { @current = @state }
     end
 
@@ -94,10 +94,12 @@ class MicroMachineTest < Test::Unit::TestCase
       @machine.trigger(:reset)
       assert_equal "Pending", @state
       assert_equal "Pending", @current
+    end
 
-      @machine.trigger(:ignore)
-      assert_equal "Ignored", @state
-      assert_equal "Ignored", @current
+    should "pass arguments to callbacks" do
+      @machine.trigger(:ignore, "State", "Ignored")
+      assert_equal "State: Ignored", @state
+      assert_equal "State: Ignored", @current
     end
   end
 


### PR DESCRIPTION
Extended trigger to accept additional arguments which will be
passed to all callbacks, this allows to pass around informations
like the actor or other contextual details.

``` ruby
# Register callback with argument
machine.on(:confirmed) { |user| "admin" if user.admin? }

# Pass around current user as argument
machine.trigger(:confirm, current_user)
```

Also included tests to verify it works as advertized.
