### PR TITLE
the states method returns all defined states

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -38,6 +38,12 @@ class MicroMachine
     transitions_for.keys
   end
 
+  def states
+    transitions_for.values.map do |transition|
+      [transition.keys, transition.values].flatten
+    end.flatten.uniq
+  end
+
   def ==(some_state)
     state == some_state
   end

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -139,4 +139,21 @@ class MicroMachineTest < Test::Unit::TestCase
       assert_equal :ignored, @model.state
     end
   end
+
+  context 'introspection' do
+    setup do
+      @machine = MicroMachine.new(:pending)
+      @machine.transitions_for[:confirm]  = { :pending => :confirmed }
+      @machine.transitions_for[:ignore]   = { :pending => :ignored }
+      @machine.transitions_for[:reset]    = { :confirmed => :pending, :ignored => :pending }
+    end
+
+    should 'return a list of defined events' do
+      assert_equal [:confirm, :ignore, :reset], @machine.events
+    end
+
+    should 'return a list of defined states' do
+      assert_equal [:pending, :confirmed, :ignored], @machine.states
+    end
+  end
 end


### PR DESCRIPTION
a project of mine needs to inspect the state-machine for all defined states. It would be handy to have a `#states` method similar to the `#events` method, which returns an array of all the defined states.

The implementation is kinda ugly feel free to replace it with a more performant/readable one.

I've also added a test for the #events method, which was missing.
