### PR TITLE
Adding exception raising option to the `trigger` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pkg
+.rvmrc

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ machine.trigger?(:reset)   #=> true
 machine.state              #=> :ignored
 ```
 
+If you want to force an Exception raise when trying to trigger a event from a
+non compatible state use the `:exception` option:
+
+``` ruby
+machine.trigger?(:ignore)                     #=> false
+machine.trigger(:ignore, :exception => true)  #=> MicroMachine::InvalidState raised
+```
+
 It can also have callbacks when entering some state:
 
 ``` ruby

--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -1,5 +1,6 @@
 class MicroMachine
   InvalidEvent = Class.new(NoMethodError)
+  InvalidState = Class.new(ArgumentError)
 
   attr :transitions_for
   attr :state
@@ -18,13 +19,14 @@ class MicroMachine
     transitions_for[event] = transitions
   end
 
-  def trigger event
+  def trigger(event, opts = {})
     if trigger?(event)
       @state = transitions_for[event][@state]
       callbacks = @callbacks[@state] + @callbacks[:any]
       callbacks.each { |callback| callback.call }
       true
     else
+      raise InvalidState.new("Event '#{event}' not valid from state '#{@state}'") if opts[:exception]
       false
     end
   end

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -40,6 +40,18 @@ class MicroMachineTest < Test::Unit::TestCase
         @machine.trigger(:random_event)
       end
     end
+
+    should "raise an error if event is triggered from/to a non complatible state and exception flag activated" do
+      assert_raise MicroMachine::InvalidState do
+        @machine.trigger(:reset, :exception => true)
+      end
+    end
+
+    should "not raise an error if event is triggered from/to a non complatible state and exception flag not activated" do
+      assert_nothing_raised do
+        @machine.trigger(:reset)
+      end
+    end
   end
 
   context "using when for defining transitions" do


### PR DESCRIPTION
Not having an in-house event triggering protection is making the _state machine_ very less powerful because then I have to surround all the `trigger` calls with `if` sentences in order to guarantee the state change has been executed.

Let me know if you prefer other kind of API like `machine.trigger!(:event)` or anything else. I think the `!` is always ambiguous so I decided for a more explicit API. 
