### PR TITLE
Add missing parentheses around arguments in method definitions.

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -4,13 +4,13 @@ class MicroMachine
   attr :transitions_for
   attr :state
 
-  def initialize initial_state
+  def initialize(initial_state)
     @state = initial_state
     @transitions_for = Hash.new
     @callbacks = Hash.new { |hash, key| hash[key] = [] }
   end
 
-  def on key, &block
+  def on(key, &block)
     @callbacks[key] << block
   end
 
@@ -18,7 +18,7 @@ class MicroMachine
     transitions_for[event] = transitions
   end
 
-  def trigger event
+  def trigger(event)
     if trigger?(event)
       @state = transitions_for[event][@state]
       callbacks = @callbacks[@state] + @callbacks[:any]

--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -10,8 +10,8 @@ class MicroMachine
     @callbacks = Hash.new { |hash, key| hash[key] = [] }
   end
 
-  def on(key, &block)
-    @callbacks[key] << block
+  def on(state, &block)
+    @callbacks[state] << block
   end
 
   def when(event, transitions)


### PR DESCRIPTION
Closes #10.