### PR TITLE
Define transitions using array for source states

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -16,7 +16,7 @@ class MicroMachine
   end
 
   def when(event, transitions)
-    transitions_for[event] = transitions
+    transitions_for[event] = flatten_transitions(transitions)
   end
 
   def trigger(event)
@@ -53,5 +53,15 @@ class MicroMachine
 
   def ==(some_state)
     state == some_state
+  end
+
+  private
+
+  def flatten_transitions(transitions)
+    f_trans = {}
+    transitions.each do |src, dst|
+      [*src].each { |s| f_trans[s] = dst }
+    end
+    f_trans
   end
 end

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -59,7 +59,7 @@ class MicroMachineTest < Test::Unit::TestCase
       @machine = MicroMachine.new(:pending)
       @machine.when(:confirm, :pending => :confirmed)
       @machine.when(:ignore, :pending => :ignored)
-      @machine.when(:reset, :confirmed => :pending, :ignored => :pending)
+      @machine.when(:reset, [:confirmed, :ignored] => :pending)
     end
 
     should "discern transitions" do


### PR DESCRIPTION
Example:

``` ruby
@machine.when(:reset, [:confirmed, :ignored] => :pending)
# instead of
@machine.when(:reset, :confirmed => :pending, :ignored => :pending)
```
