### PR TITLE
Adding the event name to the callback call

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -23,7 +23,7 @@ class MicroMachine
     if trigger?(event)
       @state = transitions_for[event][@state]
       callbacks = @callbacks[@state] + @callbacks[:any]
-      callbacks.each { |callback| callback.call }
+      callbacks.each { |callback| callback.call(event) }
       true
     else
       false

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -113,6 +113,22 @@ class MicroMachineTest < Test::Unit::TestCase
     end
   end
 
+  context "passing the event name to the callbacks" do
+    setup do
+      @machine = MicroMachine.new(:pending)
+      @machine.when(:confirm, :pending => :confirmed)
+
+      @machine.on(:confirmed) { |event_name| @event_name = event_name }
+      @machine.on(:any)       { |event_name| @any_event_name = [event_name, :any] }
+    end
+
+    should "should execute callbacks when entering a state" do
+      @machine.trigger(:confirm)
+      assert_equal :confirm, @event_name
+      assert_equal [:confirm, :any], @any_event_name
+    end
+  end
+
   context "dealing with from a model callbacks" do
     class Model
       attr_accessor :state


### PR DESCRIPTION
Given the presence of the :any event it can be helpful to know which
event was fired.

It is also possible that we are passing a reused anonymous function to
the event. In that case, it is helpful to know which event fired.

Conflicts:
	test/all_test.rb