### PR TITLE
Provide old and new state values to callbacks

### DIFF
--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -21,9 +21,20 @@ class MicroMachine
 
   def trigger(event)
     if trigger?(event)
-      @state = transitions_for[event][@state]
+      old_state, @state = @state, transitions_for[event][@state]
       callbacks = @callbacks[@state] + @callbacks[:any]
-      callbacks.each { |callback| callback.call(event) }
+      callbacks.each { |callback|
+        case callback.arity
+        when 0
+          callback.call
+        when 1
+          callback.call(event)
+        when 2
+          callback.call(event, old_state)
+        else
+          callback.call(event, old_state, @state)
+        end
+      }
       true
     else
       false

--- a/test/callback_arguments.rb
+++ b/test/callback_arguments.rb
@@ -1,0 +1,34 @@
+require_relative 'helper'
+
+setup do
+  machine = MicroMachine.new(:pending)
+  machine.when(:confirm, pending: :confirmed)
+  machine
+end
+
+test "pass the event name to the callbacks" do |machine|
+  machine.on(:confirmed) do |event|
+    assert_equal(:confirm, event)
+  end
+
+  machine.trigger(:confirm)
+end
+
+test "pass the event name and old state to the callbacks" do |machine|
+  machine.on(:confirmed) do |event, old_state|
+    assert_equal(:confirm, event)
+    assert_equal(:pending, old_state)
+  end
+
+  machine.trigger(:confirm)
+end
+
+test "pass the event name and both states to the callbacks" do |machine|
+  machine.on(:confirmed) do |event, old_state, new_state|
+    assert_equal(:confirm, event)
+    assert_equal(:pending, old_state)
+    assert_equal(:confirmed, new_state)
+  end
+
+  machine.trigger(:confirm)
+end

--- a/test/callback_method_arguments.rb
+++ b/test/callback_method_arguments.rb
@@ -1,0 +1,84 @@
+require_relative 'helper'
+
+setup do
+  klass = Class.new do
+    attr_reader :event, :old_state, :new_state, :called
+
+    def initialize
+      @event = @old_state = @new_state = nil
+      @called = false
+    end
+
+    def no_args
+      @called = true
+    end
+
+    def one_arg(event)
+      @event = event
+      @called = true
+    end
+
+    def two_args(event, old_state)
+      @event, @old_state = event, old_state
+      @called = true
+    end
+
+    def three_args(event, old_state, new_state)
+      @event, @old_state, @new_state = event, old_state, new_state
+      @called = true
+    end
+  end
+
+  machine = MicroMachine.new(:pending)
+  machine.when(:confirm, pending: :confirmed)
+
+  [ klass.new, machine ]
+end
+
+test "does not raise an exception when arity is 0" do |object, machine|
+  machine.on(:confirmed, &object.method(:no_args))
+
+  assert !object.called
+
+  assert_nothing_raised { machine.trigger(:confirm) }
+  assert object.called
+  assert object.event.nil?
+  assert object.old_state.nil?
+  assert object.new_state.nil?
+end
+
+test "gets the event only when arity is 1" do |object, machine|
+  machine.on(:confirmed, &object.method(:one_arg))
+
+  assert !object.called
+
+  assert_nothing_raised { machine.trigger(:confirm) }
+  assert object.called
+  assert_equal(:confirm, object.event)
+  assert object.old_state.nil?
+  assert object.new_state.nil?
+end
+
+test "gets the event and old state when arity is 2" do |object, machine|
+  machine.on(:confirmed, &object.method(:two_args))
+
+  assert !object.called
+
+  assert_nothing_raised { machine.trigger(:confirm) }
+  assert object.called
+  assert_equal(:confirm, object.event)
+  assert_equal(:pending, object.old_state)
+  assert object.new_state.nil?
+end
+
+test "gets the event and both states when arity is 3" do |object, machine|
+  machine.on(:confirmed, &object.method(:three_args))
+
+  assert !object.called
+
+  assert_nothing_raised { machine.trigger(:confirm) }
+  assert object.called
+  assert_equal(:confirm, object.event)
+  assert_equal(:pending, object.old_state)
+  assert_equal(:confirmed, object.new_state)
+end

--- a/test/callbacks.rb
+++ b/test/callbacks.rb
@@ -35,10 +35,8 @@ test "passing the event name to the callbacks" do
   machine.when(:confirm, pending: :confirmed)
 
   machine.on(:confirmed) do |event|
-    event_name = event
+    assert_equal(:confirm, event)
   end
 
   machine.trigger(:confirm)
-
-  assert_equal(:confirm, event_name)
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,2 +1,12 @@
 require "cutest"
 require_relative "../lib/micromachine"
+
+module Kernel
+  private
+  def assert_nothing_raised
+    yield
+    success
+  rescue Exception => exception
+    flunk("got #{exception.inspect} instead of nothing")
+  end
+end


### PR DESCRIPTION
- It may be useful to know which state you are coming from, especially if a state can be reached from previous states.

- This uses the `callback.arity` to determine whether the pre-1.2 behaviour should be supported, whether 1.2 behaviour should be supported (event only), whether the old state should be provided (because you can always ask for `#state`) or whether both old and new states should be provided. The `else` *should probably* be checking for `3` or `-1` rather than always passing all three, but the behaviour under that case is unclear. This fixes #26.

- The `assert_nothing_raised` helper in test/helper.rb has been proposed as djanowski/cutest#25.