### PR TITLE
Some minor cleanup based on the second Codalyzed video.

### DIFF
--- a/examples/advanced.rb
+++ b/examples/advanced.rb
@@ -1,6 +1,6 @@
 require 'micromachine'
 
-# This example can be run with ruby -I lib/ example/advanced.rb
+# This example can be run with ruby -I lib/ ./examples/advanced.rb
 
 fsm = MicroMachine.new(:pending)
 

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -1,6 +1,6 @@
 require 'micromachine'
 
-# This example can be run with ruby -I lib/ example/basic.rb
+# This example can be run with ruby -I lib/ ./examples/basic.rb
 
 fsm = MicroMachine.new(:pending)
 

--- a/examples/callbacks.rb
+++ b/examples/callbacks.rb
@@ -1,6 +1,6 @@
 require 'micromachine'
 
-# This example can be run with ruby -I lib/ example/callbacks.rb
+# This example can be run with ruby -I lib/ ./examples/callbacks.rb
 
 fsm = MicroMachine.new(:pending)
 

--- a/test/introspection.rb
+++ b/test/introspection.rb
@@ -17,11 +17,3 @@ end
 test "returns an array with the defined states" do |machine|
   assert_equal [:pending, :confirmed, :ignored], machine.states
 end
-
-test "returns false if compared state is not equal to current" do |machine|
-  assert !(machine == :confirmed)
-end
-
-test "returns true if compared state is equal to current" do |machine|
-  assert machine == :pending
-end


### PR DESCRIPTION
This is the patch you built, except I restored one line to the way it was before:

```ruby
raise InvalidEvent unless transitions_for.has_key?(event)
```

I would say this `raise … if/unless …` is a standard form for guard clauses like this and it's probably better to follow the norm in this case.