### PR TITLE
Add ability to pass arbitrary payload from `trigger` to callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ end
 Note that `:any` is a special key. Using it as a state when declaring
 transitions will give you unexpected results.
 
+You can also pass any data as the second argument for `trigger` and `trigger!`
+which will be passed to every callback as the second argument too:
+
+``` ruby
+machine.on(:any) do |_status, payload|
+  puts payload.inspect
+end
+
+machine.trigger(:cancel, from: :user)
+```
+
 Finally, you can list possible events or states:
 
 ``` ruby

--- a/lib/micromachine.rb
+++ b/lib/micromachine.rb
@@ -19,12 +19,12 @@ class MicroMachine
     transitions_for[event] = transitions
   end
 
-  def trigger(event)
-    trigger?(event) and change(event)
+  def trigger(event, payload = nil)
+    trigger?(event) and change(event, payload)
   end
 
-  def trigger!(event)
-    trigger(event) or
+  def trigger!(event, payload = nil)
+    trigger(event, payload) or
       raise InvalidState.new("Event '#{event}' not valid from state '#{@state}'")
   end
 
@@ -47,10 +47,10 @@ class MicroMachine
 
 private
 
-  def change(event)
+  def change(event, payload = nil)
     @state = transitions_for[event][@state]
     callbacks = @callbacks[@state] + @callbacks[:any]
-    callbacks.each { |callback| callback.call(event) }
+    callbacks.each { |callback| callback.call(event, payload) }
     true
   end
 end

--- a/test/callbacks.rb
+++ b/test/callbacks.rb
@@ -42,3 +42,18 @@ test "passing the event name to the callbacks" do
 
   assert_equal(:confirm, event_name)
 end
+
+test "passing the payload from transition to the callbacks" do
+  received_payload = nil
+
+  machine = MicroMachine.new(:pending)
+  machine.when(:confirm, pending: :confirmed)
+
+  machine.on(:confirmed) do |_event, payload|
+    received_payload = payload
+  end
+
+  machine.trigger(:confirm, foo: :bar)
+
+  assert_equal({ foo: :bar }, received_payload)
+end


### PR DESCRIPTION
Ability to pass some stuff from code, calling `trigger` to callbacks may be useful for some logging purposes and etc, For example:

```rb
def cancel!(by:)
  machine.trigger(:cancel, by: by)
end

# …

machine.on(:any) do |status, payload|
  status_log_entries.create(status: status, payload: payload) 
end
```
